### PR TITLE
Fix some bugs for error trace exploration [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ junit[0-9]*.properties
 junitvmwatcher[0-9]*.properties
 test.jfr
 *.jfr
+*.prefs

--- a/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
@@ -99,6 +99,7 @@ public class TraceExplorationSpec {
 			TraceExplorer.writeSpecTEStreams(
 					teSpecModuleName,
 					ogModuleName,
+					null,
 					constants,
 					variables,
 					errorTrace,

--- a/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorer.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorer.java
@@ -214,11 +214,7 @@ public class TraceExplorer {
 		te.addPrimer(String.format("%s_%s", originalSpecName, TLAConstants.TraceExplore.EXPLORATION_MODULE_NAME),
 				originalSpecName, extendedModules);
 		te.append(modelValuesAsConstants);
-		te.addTraceExpressionStub(TLAConstants.TraceExplore.SPEC_TE_TRACE_EXPRESSION, variables);
-		if (expressionsInput != null) {
-			// Merge the input trace expressions (which should be a stringified TLA+ Structure) with the variables.
-			te.append("@@ " + expressionsInput + TLAConstants.CR);
-		}
+		te.addTraceExpressionStub(TLAConstants.TraceExplore.SPEC_TE_TRACE_EXPRESSION, variables, expressionsInput);		
 		te.addFooter();
 		writer.append(TLAConstants.CR + te.toString() + TLAConstants.CR + TLAConstants.CR);
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorer.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorer.java
@@ -208,11 +208,17 @@ public class TraceExplorer {
 		 * Write definition of trace expression into new module.
 		 */
 		writer.append(TLAConstants.CR);
-
+		
 		final SpecTraceExpressionWriter te = new SpecTraceExpressionWriter();
-		te.append(TLAConstants.CR);
-		te.addPrimer(String.format("%s_%s", originalSpecName, TLAConstants.TraceExplore.EXPLORATION_MODULE_NAME),
-				originalSpecName, extendedModules);
+		final String teModuleName = String.format("%s_%s", originalSpecName, TLAConstants.TraceExplore.EXPLORATION_MODULE_NAME);
+		te.append(TLAConstants.CR);		
+		writer.append(String.format("You can copy and paste the module `%s`", teModuleName)).append(TLAConstants.CR);
+		writer.append(" to its own file so you are able to keep your trace").append(TLAConstants.CR);
+		writer.append(" expression after each `TTrace.tla` regeneration,").append(TLAConstants.CR);
+		writer.append(" don't having to rewrite it again.").append(TLAConstants.CR);
+		writer.append(" A standalone module has priority over a module in").append(TLAConstants.CR);
+		writer.append(" a monolith file.");		
+		te.addPrimer(teModuleName, originalSpecName, extendedModules);
 		te.append(modelValuesAsConstants);
 		te.addTraceExpressionStub(TLAConstants.TraceExplore.SPEC_TE_TRACE_EXPRESSION, variables, expressionsInput);		
 		te.addFooter();

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/SpecTraceExpressionWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/SpecTraceExpressionWriter.java
@@ -703,7 +703,7 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * Adds the invariant ~(P) where P is the formula describing finalState. The format
 	 * in the tla file is as follows:
 	 * 
-	 * inv_12312321321 ==
+	 * _inv ==
 	 * ~(
 	 * P
 	 * )
@@ -711,8 +711,8 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * 
 	 * @param finalState
 	 */
-	public void addInvariant(final MCState finalState) {
-	    final String id = SpecWriterUtilities.getValidIdentifier(TLAConstants.Schemes.INVARIANT_SCHEME);
+	private void addInvariant(final MCState finalState) {
+	    final String id = SpecWriterUtilities.getValidIdentifierNoTimestamp(TLAConstants.Schemes.INVARIANT_SCHEME);
 	    cfgBuffer.append(TLAConstants.COMMENT).append(TLAConstants.KeyWords.INVARIANT).append(" definition");
 	    cfgBuffer.append(TLAConstants.CR).append(TLAConstants.KeyWords.INVARIANT).append(TLAConstants.CR);
 	    cfgBuffer.append(id).append(TLAConstants.CR);
@@ -777,7 +777,7 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * Adds the temporal property ~<>[](P) where P is the formula describing finalState.
 	 * The format in the tla file is as follows:
 	 * 
-	 * prop_23112321 ==
+	 * _prop ==
 	 * ~<>[](
 	 * P
 	 * )
@@ -785,8 +785,8 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * 
 	 * @param finalState
 	 */
-	public void addStutteringProperty(final MCState finalState) {
-	    String id = SpecWriterUtilities.getValidIdentifier(TLAConstants.Schemes.PROP_SCHEME);
+	private void addStutteringProperty(final MCState finalState) {
+	    String id = SpecWriterUtilities.getValidIdentifierNoTimestamp(TLAConstants.Schemes.PROP_SCHEME);
 	    cfgBuffer.append(TLAConstants.COMMENT).append(TLAConstants.KeyWords.PROPERTY).append(" definition");
 	    cfgBuffer.append(TLAConstants.CR).append(TLAConstants.KeyWords.PROPERTY).append(TLAConstants.CR);
 	    cfgBuffer.append(id).append(TLAConstants.CR);
@@ -802,7 +802,7 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * Adds the temporal property ~([]<>P /\ []<>Q), where P is the formula describing finalState and 
 	 * Q the formula describing backToState. The formatting in the tla file is as follows:
 	 * 
-	 * prop_21321312 ==
+	 * _prop ==
 	 * ~(([]<>(
 	 * P
 	 * ))/\([]<>(
@@ -813,8 +813,8 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * @param finalState
 	 * @param backToState
 	 */
-	public void addBackToStateProperty(final MCState finalState, final MCState backToState) {
-	    final String id = SpecWriterUtilities.getValidIdentifier(TLAConstants.Schemes.PROP_SCHEME);
+	private void addBackToStateProperty(final MCState finalState, final MCState backToState) {
+	    final String id = SpecWriterUtilities.getValidIdentifierNoTimestamp(TLAConstants.Schemes.PROP_SCHEME);
 	    cfgBuffer.append(TLAConstants.COMMENT).append(TLAConstants.KeyWords.PROPERTY).append(" definition");
 	    cfgBuffer.append(TLAConstants.CR).append(TLAConstants.KeyWords.PROPERTY).append(TLAConstants.CR);
 	    cfgBuffer.append(id).append(TLAConstants.CR);
@@ -978,11 +978,11 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	public String addTraceFunctionInstance() {
 		/*
 		 * SpecTETraceDef == INSTANCE SpecTETraceDef
-		 * def_ov_15940964130543000 == SpecTETraceDef!def_ov_15940964130543000
+		 * _def_ov == SpecTETraceDef!def_ov_15940964130543000
 		 */
 		tlaBuffer.append(TLAConstants.COMMENT).append(TLAConstants.TraceExplore.ERROR_STATES_MODULE_NAME)
 				.append(" definition").append(TLAConstants.CR);
-		final String identifier = SpecWriterUtilities.getValidIdentifier(TLAConstants.Schemes.DEFOV_SCHEME);
+		final String identifier = SpecWriterUtilities.getValidIdentifierNoTimestamp(TLAConstants.Schemes.DEFOV_SCHEME);
 		tlaBuffer.append(TLAConstants.TraceExplore.TRACE_EXPRESSION_MODULE_NAME + "TraceDef == INSTANCE "
 				+ TLAConstants.TraceExplore.TRACE_EXPRESSION_MODULE_NAME
 				+ TLAConstants.TraceExplore.ERROR_STATES_MODULE_NAME).append(TLAConstants.CR);

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/SpecTraceExpressionWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/SpecTraceExpressionWriter.java
@@ -613,7 +613,7 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 	 * @param teName Name of trace expression.
 	 * @param variables Spec variables; transformed by identity.
 	 */
-	public void addTraceExpressionStub(String teName, final List<String> variables) {
+	public void addTraceExpressionStub(String teName, final List<String> variables, String expressionsInput) {
 		this.tlaBuffer.append(teName + TLAConstants.DEFINES + TLAConstants.CR);
 		this.tlaBuffer
 				.append(TLAConstants.INDENT + TLAConstants.L_SQUARE_BRACKET + TLAConstants.CR + TLAConstants.INDENT);
@@ -624,7 +624,12 @@ public class SpecTraceExpressionWriter extends AbstractSpecWriter {
 		this.tlaBuffer.append(TLAConstants.INDENT + TLAConstants.INDENT + TLAConstants.COMMENT + "Put additional trace expressions here; examples:" + TLAConstants.CR);
 		this.tlaBuffer.append(TLAConstants.INDENT + TLAConstants.INDENT + TLAConstants.COMMENT + TLAConstants.COMMA + "x" + TLAConstants.RECORD_ARROW + TLAConstants.TLA_NOT + "y" + TLAConstants.PRIME + TLAConstants.CR);
 		this.tlaBuffer.append(TLAConstants.INDENT + TLAConstants.INDENT + TLAConstants.COMMENT + TLAConstants.COMMA + "e" + TLAConstants.RECORD_ARROW + TLAConstants.KeyWords.ENABLED + TLAConstants.SPACE + "ActionName" + TLAConstants.CR);
-		this.tlaBuffer.append(TLAConstants.INDENT + TLAConstants.R_SQUARE_BRACKET + TLAConstants.CR + TLAConstants.CR);
+		this.tlaBuffer.append(TLAConstants.INDENT + TLAConstants.R_SQUARE_BRACKET);
+		if (expressionsInput != null) {
+			// Merge the input trace expressions (which should be a stringified TLA+ Structure) with the variables.
+			this.tlaBuffer.append(" @@ " + expressionsInput);
+		}
+		this.tlaBuffer.append(TLAConstants.CR + TLAConstants.CR);
 	}
 
 	public void addFooter() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/SpecWriterUtilities.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/SpecWriterUtilities.java
@@ -77,12 +77,22 @@ public final class SpecWriterUtilities {
     						  + TLAConstants.Schemes.PROP_SCHEME + ")_[0-9]{17,}");
 
     /**
-     * Creates a new valid unqiue identifier from given scheme
+     * Creates a new valid unqiue identifier with timestamp from given scheme.
      * @param scheme a naming scheme, one of the {@link TLAConstants.Schemes} constants
      * @return a valid identifier
      */
 	public static String getValidIdentifier(final String scheme) {
 		return String.format("%s_%s%s", scheme, System.currentTimeMillis(), 1000 * COUNTER.incrementAndGet());
+    }
+    
+    /**
+     * Creates a new valid unqiue identifier without timestamp from given scheme. 
+     * This was created to not mess with {@link getValidIdentifier} which is used by other classes. 
+     * @param scheme a naming scheme, one of the {@link TLAConstants.Schemes} constants
+     * @return a valid identifier
+     */
+	public static String getValidIdentifierNoTimestamp(final String scheme) {
+		return String.format("_%s", scheme);
 	}
 
     /**


### PR DESCRIPTION
It's in WIP, will add tests later.

Original (for the future) TODO (both for here and for the VSCode extension PR) (can be dealt with later):
- [ ]  Add CustomTextEditor.
- [ ]  Check for errors at trace expression (`Structure`).
- [ ]  Reference original TLA lines instead of `TTrace`.
- [ ]  Show `TraceExplorer` runner errors.
- [ ] Continue using `Structure`?
- [ ] Create better UX to add TEs?
- [x] Use `_` for variables names instead of having them suffixed by a time-stamp.
- [ ] Add tests.
- [ ] Add some little documentation on how to use it (both in code and README).
- [ ] Delete `TraceExplorer` unused code, I'll assume nobody is already using it.

Main TODO:
- [x] Make the name better with `_` as the prefix for operations instead of using timestamps.
- [x] Check if the `TTrace` file is human-readable, the user can have the option to change there directly.
- [x] Add comments to `.*_TE` module saying that this can be a separate file (and add/improve comments elsewhere).
- [x] Be aware of indentation.
- [x] Import JSON dependencies to TLC.
- [x] See how to get rid of the /tmp... when parsing the modules, show where it's coming from instead (it should be coming from some Jar). Better, we will show it alongside with the original location.
- [ ] JSON trace ([https://github.com/tlaplus/tlaplus/issues/555](https://github.com/tlaplus/tlaplus/issues/555)).
- [ ] Maybe check a better way to add trace expressions.
- [ ] Check if it's not messing with the Toolbox.
